### PR TITLE
Fix for salvagers not collecting money for Indy

### DIFF
--- a/becti_0097_z1214_SS.Altis/server/FSM/update_salvager.fsm
+++ b/becti_0097_z1214_SS.Altis/server/FSM/update_salvager.fsm
@@ -171,7 +171,7 @@ class FSM
        "	if !(isNil '_var_classname') then {" \n
        "		_side = side driver _salvager;" \n
        "		_group = group driver _salvager;" \n
-       "		if (_side in [west,east]) then {" \n
+       "		if (_side in [west,east,resistance]) then {" \n
        "			_salvage_value = round((_var_classname select 2) * CTI_VEHICLES_SALVAGE_RATE);" \n
        "			_commander_get = 0;" \n
        "			_player_get = 0;" \n


### PR DESCRIPTION
Salvage trucks were not able to collect money from indy/green vehicle
wrecks. The fix was just to add `resistance` to the allowed sides that a
salvager can collect from.

I've tested this fix on local server, and I've seen both independent and
player driven salvager trucks collect money from indy wrecks.

This fixes #60.
