### PR TITLE
Restore instant structure building with CTI_DEBUG

### DIFF
--- a/becti_0097_z1214_SS.Altis/common/Init/Init_CommonConstants.sqf
+++ b/becti_0097_z1214_SS.Altis/common/Init/Init_CommonConstants.sqf
@@ -378,6 +378,7 @@ CTI_BASE_AREA_MAX = 2;
 CTI_BASE_AREA_RANGE = 300;  //ss83 reduced from 500
 
 //--- Base: Construction
+CTI_BASE_CONSTRUCTION_TIME = 180; //--- Length of time a structure takes to build, in seconds.
 CTI_BASE_CONSTRUCTION_DECAY_TIMEOUT = 300; //--- Decay starts after x seconds unattended.
 CTI_BASE_CONSTRUCTION_DECAY_DELAY = 1; //--- Decay each x seconds.
 CTI_BASE_CONSTRUCTION_DECAY_FROM = 0.50; //--- Decay of x / 100 each y seconds.

--- a/becti_0097_z1214_SS.Altis/server/functions/Server_HandleStructureConstruction.sqf
+++ b/becti_0097_z1214_SS.Altis/server/functions/Server_HandleStructureConstruction.sqf
@@ -71,7 +71,9 @@ if (_isDestroyed) then {
     };
 } else {
     //--- Normal construction cycle
-    sleep 180;  //this timer determines how long it takes for the structure to pop up, ss83
+    if(!CTI_DEBUG) then {
+        sleep CTI_BASE_CONSTRUCTION_TIME; //this timer determines how long it takes for the structure to pop up, ss83
+    };	
     _completion = 100;
 }; 
 


### PR DESCRIPTION
This commit restores the ability to insta-build structures in debugging mode.

The easier it is to test and develop, the fewer bugs we should have.

(I've also moved the time-to-build setting to the constants file, which is
where it should live.)
